### PR TITLE
Mixins to enable paginated feeds.

### DIFF
--- a/major_event_log/feeds.py
+++ b/major_event_log/feeds.py
@@ -22,18 +22,32 @@ class PaginatedFeedTypeMixin(object):
             "link", "", {"rel": "alternate", "href": self.feed['link']})
 
         if self.feed['feed_url'] is not None:
-            handler.addQuickElement("link", "", {"rel": "self", "href": self.feed['feed_url']})
+            handler.addQuickElement(
+                "link", "", {"rel": "self", "href": self.feed['feed_url']})
 
-        handler.addQuickElement(u'link', '', self._create_link_attr(u'first', 1))
-        handler.addQuickElement(u'link', '', self._create_link_attr(u'last', self.feed['last_page']))
+        handler.addQuickElement(
+            u'link', '', self._create_link_attr(u'first', 1))
+
+        handler.addQuickElement(
+            u'link',
+            '',
+            self._create_link_attr(u'last', self.feed['last_page']))
 
         if self.feed.get('prev_page', None) is not None:
-            handler.addQuickElement(u'link', '', self._create_link_attr(u'prev_page', self.feed['prev_page']))
+            handler.addQuickElement(
+                u'link',
+                '',
+                self._create_link_attr(u'prev_page', self.feed['prev_page']))
+
         if self.feed.get('next_page', None) is not None:
-            handler.addQuickElement(u'link', '', self._create_link_attr(u'next_page', self.feed['next_page']))
+            handler.addQuickElement(
+                u'link',
+                '',
+                self._create_link_attr(u'next_page', self.feed['next_page']))
 
         handler.addQuickElement("id", self.feed['id'])
-        handler.addQuickElement("updated", rfc3339_date(self.latest_post_date()))
+        handler.addQuickElement(
+            "updated", rfc3339_date(self.latest_post_date()))
 
         if self.feed['author_name'] is not None:
             handler.startElement("author", {})

--- a/major_event_log/feeds.py
+++ b/major_event_log/feeds.py
@@ -2,7 +2,7 @@
 
 from django.contrib.syndication.views import Feed
 from django.core.urlresolvers import reverse, reverse_lazy
-from django.utils.feedgenerator import Atom1Feed
+from django.utils.feedgenerator import Atom1Feed, rfc3339_date
 from django.core.paginator import Paginator
 
 from .models import Event
@@ -17,7 +17,6 @@ class PaginatedFeedTypeMixin(object):
         return {u'rel': rel, u'href': href}
 
     def add_root_elements(self, handler):
-        from django.utils.feedgenerator import rfc3339_date
         handler.addQuickElement("title", self.feed['title'])
         handler.addQuickElement(
             "link", "", {"rel": "alternate", "href": self.feed['link']})

--- a/major_event_log/feeds.py
+++ b/major_event_log/feeds.py
@@ -39,19 +39,22 @@ class PaginatedAtom1FeedMixin(object):
         handler.addQuickElement(
             u'link',
             '',
-            self._create_link_attr(u'last', self.feed['last_page']))
+            self._create_link_attr(u'last', self.feed['last_page'])
+        )
 
         if self.feed.get('prev_page', None) is not None:
             handler.addQuickElement(
                 u'link',
                 '',
-                self._create_link_attr(u'prev_page', self.feed['prev_page']))
+                self._create_link_attr(u'prev_page', self.feed['prev_page'])
+            )
 
         if self.feed.get('next_page', None) is not None:
             handler.addQuickElement(
                 u'link',
                 '',
-                self._create_link_attr(u'next_page', self.feed['next_page']))
+                self._create_link_attr(u'next_page', self.feed['next_page'])
+            )
 
         handler.addQuickElement('id', self.feed['id'])
         handler.addQuickElement(
@@ -60,10 +63,13 @@ class PaginatedAtom1FeedMixin(object):
         if self.feed['author_name'] is not None:
             handler.startElement('author', {})
             handler.addQuickElement('name', self.feed['author_name'])
+
             if self.feed['author_email'] is not None:
                 handler.addQuickElement('email', self.feed['author_email'])
+
             if self.feed['author_link'] is not None:
                 handler.addQuickElement('uri', self.feed['author_link'])
+
             handler.endElement('author')
 
         if self.feed['subtitle'] is not None:

--- a/major_event_log/feeds.py
+++ b/major_event_log/feeds.py
@@ -25,13 +25,13 @@ class PaginatedAtom1FeedMixin(object):
         in order to place the additional link elements into the
         desired location in the document.
         """
-        handler.addQuickElement("title", self.feed['title'])
+        handler.addQuickElement('title', self.feed['title'])
         handler.addQuickElement(
-            "link", "", {"rel": "alternate", "href": self.feed['link']})
+            'link', '', {'rel': 'alternate', 'href': self.feed['link']})
 
         if self.feed['feed_url'] is not None:
             handler.addQuickElement(
-                "link", "", {"rel": "self", "href": self.feed['feed_url']})
+                'link', '', {'rel': 'self', 'href': self.feed['feed_url']})
 
         handler.addQuickElement(
             u'link', '', self._create_link_attr(u'first', 1))
@@ -53,27 +53,27 @@ class PaginatedAtom1FeedMixin(object):
                 '',
                 self._create_link_attr(u'next_page', self.feed['next_page']))
 
-        handler.addQuickElement("id", self.feed['id'])
+        handler.addQuickElement('id', self.feed['id'])
         handler.addQuickElement(
-            "updated", rfc3339_date(self.latest_post_date()))
+            'updated', rfc3339_date(self.latest_post_date()))
 
         if self.feed['author_name'] is not None:
-            handler.startElement("author", {})
-            handler.addQuickElement("name", self.feed['author_name'])
+            handler.startElement('author', {})
+            handler.addQuickElement('name', self.feed['author_name'])
             if self.feed['author_email'] is not None:
-                handler.addQuickElement("email", self.feed['author_email'])
+                handler.addQuickElement('email', self.feed['author_email'])
             if self.feed['author_link'] is not None:
-                handler.addQuickElement("uri", self.feed['author_link'])
-            handler.endElement("author")
+                handler.addQuickElement('uri', self.feed['author_link'])
+            handler.endElement('author')
 
         if self.feed['subtitle'] is not None:
-            handler.addQuickElement("subtitle", self.feed['subtitle'])
+            handler.addQuickElement('subtitle', self.feed['subtitle'])
 
         for cat in self.feed['categories']:
-            handler.addQuickElement("category", "", {"term": cat})
+            handler.addQuickElement('category', '', {'term': cat})
 
         if self.feed['feed_copyright'] is not None:
-            handler.addQuickElement("rights", self.feed['feed_copyright'])
+            handler.addQuickElement('rights', self.feed['feed_copyright'])
 
 
 class MajorEventLogFeed(PaginatedAtom1FeedMixin, Atom1Feed):

--- a/major_event_log/feeds.py
+++ b/major_event_log/feeds.py
@@ -8,7 +8,54 @@ from django.core.paginator import Paginator
 from .models import Event
 
 
-class MajorEventLogFeed(Atom1Feed):
+class PaginatedFeedTypeMixin(object):
+
+    def _create_link_attr(self, rel, page):
+        href = u'{0}?{1}={2}'.format(
+            self.feed['link'], self.feed['page_query'], page)
+
+        return {u'rel': rel, u'href': href}
+
+    def add_root_elements(self, handler):
+        from django.utils.feedgenerator import rfc3339_date
+        handler.addQuickElement("title", self.feed['title'])
+        handler.addQuickElement(
+            "link", "", {"rel": "alternate", "href": self.feed['link']})
+
+        if self.feed['feed_url'] is not None:
+            handler.addQuickElement("link", "", {"rel": "self", "href": self.feed['feed_url']})
+
+        handler.addQuickElement(u'link', '', self._create_link_attr(u'first', 1))
+        handler.addQuickElement(u'link', '', self._create_link_attr(u'last', self.feed['last_page']))
+
+        if self.feed.get('prev_page', None) is not None:
+            handler.addQuickElement(u'link', '', self._create_link_attr(u'prev_page', self.feed['prev_page']))
+        if self.feed.get('next_page', None) is not None:
+            handler.addQuickElement(u'link', '', self._create_link_attr(u'next_page', self.feed['next_page']))
+
+        handler.addQuickElement("id", self.feed['id'])
+        handler.addQuickElement("updated", rfc3339_date(self.latest_post_date()))
+
+        if self.feed['author_name'] is not None:
+            handler.startElement("author", {})
+            handler.addQuickElement("name", self.feed['author_name'])
+            if self.feed['author_email'] is not None:
+                handler.addQuickElement("email", self.feed['author_email'])
+            if self.feed['author_link'] is not None:
+                handler.addQuickElement("uri", self.feed['author_link'])
+            handler.endElement("author")
+
+        if self.feed['subtitle'] is not None:
+            handler.addQuickElement("subtitle", self.feed['subtitle'])
+
+        for cat in self.feed['categories']:
+            handler.addQuickElement("category", "", {"term": cat})
+
+        if self.feed['feed_copyright'] is not None:
+            handler.addQuickElement("rights", self.feed['feed_copyright'])
+
+
+class MajorEventLogFeed(PaginatedFeedTypeMixin, Atom1Feed):
     """Custom Atom Feed for Event objects.
 
     The only changes between this custom feed and the base Atom Feed
@@ -18,85 +65,55 @@ class MajorEventLogFeed(Atom1Feed):
 
     mime_type = 'application/xml'
 
-    def add_root_elements(self, handler):
-        handler.addQuickElement(u'title', self.feed['title'])
-        handler.addQuickElement(
-            u'link', '', {u'rel': u'self', u'href': self.feed['feed_url']}
-        )
-        handler.addQuickElement(u'id', self.feed['id'])
-        handler.startElement(u'author', {})
-        handler.addQuickElement(u'name', self.feed['author_name'])
-        handler.addQuickElement(u'uri', self.feed['author_link'])
-        handler.endElement(u'author')
-        handler.addQuickElement(u'subtitle', self.feed['subtitle'])
-        handler.addQuickElement(
-            u'link',
-            '',
-            {u'rel': u'first', u'href': '{}?p=1'.format(self.feed['link'])}
-        )
-        handler.addQuickElement(
-            u'link',
-            '',
-            {
-                u'rel': u'last',
-                u'href': '{}?p={}'.format(self.feed['link'],
-                                          self.feed['last_link'])
-            }
-        )
-        if self.feed.get('prev_link', None) is not None:
-            handler.addQuickElement(
-                u'link',
-                '',
-                {
-                    u'rel': u'previous',
-                    u'href': '{}?p={}'.format(self.feed['link'],
-                                              self.feed['prev_link'])
-                }
-            )
-        if self.feed.get('next_link', None) is not None:
-            handler.addQuickElement(
-                u'link',
-                '',
-                {
-                    u'rel': u'next',
-                    u'href': '{}?p={}'.format(self.feed['link'],
-                                              self.feed['next_link'])
-                }
-            )
+
+class PaginatedFeedMixin(object):
+    paginator = None
+    page = 1
+    items_per_page = 2
+    page_query = 'page'
+
+    def setup_paginator(self, request, items):
+        self.page = request.GET.get(self.page_query, 1)
+        self.paginator = Paginator(items, self.items_per_page)
+
+    def get_page(self):
+        return self.paginator.page(self.page)
+
+    def get_page_kwargs(self):
+        page = self.get_page()
+
+        kwargs = {}
+
+        kwargs.setdefault('page_query', self.page_query)
+        if page.has_next():
+            kwargs.setdefault('next_page', page.next_page_number())
+
+        if page.has_previous():
+            kwargs.setdefault('prev_page', page.previous_page_number())
+
+        kwargs.setdefault('last_page', str(self.paginator.num_pages))
+        return kwargs
 
 
-class LatestEventsFeed(Feed):
+class LatestEventsFeed(PaginatedFeedMixin, Feed):
     feed_type = MajorEventLogFeed
     title = 'PREMIS Major Event Log'
     link = reverse_lazy('major-event-log:feed')
     subtitle = '10 most recent major PREMIS events.'
     author_name = 'Major Event Log'
     author_link = 'http://digital2.library.unt.edu/name/nm0005293/'
+    page_query = 'p'
 
     def get_object(self, request):
         display = Event.objects.order_by('-date')
-        return (display, request.GET.get('p'))
+        self.setup_paginator(request, display)
+        return display
 
     def feed_extra_kwargs(self, display):
-        extra_dict = {}
-        d = Paginator(display[0], 10)
-        p = display[1]
-        if p is None:
-            p = 1
-        cur_page = d.page(p)
-        if cur_page.has_next():
-            extra_dict.setdefault('next_link', cur_page.next_page_number())
-        if cur_page.has_previous():
-            extra_dict.setdefault('prev_link', cur_page.previous_page_number())
-        extra_dict.setdefault('last_link', str(d.num_pages))
-        return extra_dict
+        return self.get_page_kwargs()
 
-    def items(self, display):
-        p = display[1]
-        if p is None:
-            p = 1
-        d = Paginator(display[0], 10)
-        return d.page(p).object_list
+    def items(self, obj):
+        return self.get_page().object_list
 
     def item_title(self, item):
         return item.title

--- a/major_event_log/feeds.py
+++ b/major_event_log/feeds.py
@@ -26,8 +26,6 @@ class PaginatedAtom1FeedMixin(object):
         desired location in the document.
         """
         handler.addQuickElement('title', self.feed['title'])
-        handler.addQuickElement(
-            'link', '', {'rel': 'alternate', 'href': self.feed['link']})
 
         if self.feed['feed_url'] is not None:
             handler.addQuickElement(
@@ -87,14 +85,14 @@ class MajorEventLogFeed(PaginatedAtom1FeedMixin, Atom1Feed):
 
     The only changes between this custom feed and the base Atom Feed
     are that this feed specifies its mime_type as 'application/xml',
-    pagination is added, the 'alternate' link is removed.
+    pagination is added, and the 'alternate' link is removed.
     """
 
     mime_type = 'application/xml'
 
 
 class PaginatedFeedMixin(object):
-    """Feed Mixin to enable pagination."""
+    """Feed mixin to enable pagination."""
 
     paginator = None
     page = 1

--- a/major_event_log/feeds.py
+++ b/major_event_log/feeds.py
@@ -118,9 +118,9 @@ class LatestEventsFeed(PaginatedFeedMixin, Feed):
     page_field = 'p'
 
     def get_object(self, request):
-        display = Event.objects.order_by('-date')
-        self.setup_paginator(request, display)
-        return display
+        events = Event.objects.order_by('-date')
+        self.setup_paginator(request, events)
+        return events
 
     def feed_extra_kwargs(self, display):
         return self.get_page_kwargs()

--- a/major_event_log/feeds.py
+++ b/major_event_log/feeds.py
@@ -68,7 +68,7 @@ class MajorEventLogFeed(PaginatedFeedTypeMixin, Atom1Feed):
 class PaginatedFeedMixin(object):
     paginator = None
     page = 1
-    items_per_page = 2
+    items_per_page = 10
     page_query = 'page'
 
     def setup_paginator(self, request, items):

--- a/major_event_log/feeds.py
+++ b/major_event_log/feeds.py
@@ -44,14 +44,14 @@ class PaginatedAtom1FeedMixin(object):
             handler.addQuickElement(
                 u'link',
                 '',
-                self._create_link_attr(u'prev_page', self.feed['prev_page'])
+                self._create_link_attr(u'previous', self.feed['prev_page'])
             )
 
         if self.feed.get('next_page', None) is not None:
             handler.addQuickElement(
                 u'link',
                 '',
-                self._create_link_attr(u'next_page', self.feed['next_page'])
+                self._create_link_attr(u'next', self.feed['next_page'])
             )
 
         handler.addQuickElement('id', self.feed['id'])

--- a/major_event_log/feeds.py
+++ b/major_event_log/feeds.py
@@ -120,7 +120,7 @@ class PaginatedFeedMixin(object):
 
         This is intended to be called from `feed_extra_kwargs`.
         """
-        page = self.get_page()
+        page = self.get_current_page()
         kwargs = {}
 
         kwargs.setdefault('page_field', self.page_field)

--- a/major_event_log/feeds.py
+++ b/major_event_log/feeds.py
@@ -12,7 +12,7 @@ class PaginatedFeedTypeMixin(object):
 
     def _create_link_attr(self, rel, page):
         href = u'{0}?{1}={2}'.format(
-            self.feed['link'], self.feed['page_query'], page)
+            self.feed['link'], self.feed['page_field'], page)
 
         return {u'rel': rel, u'href': href}
 
@@ -69,10 +69,10 @@ class PaginatedFeedMixin(object):
     paginator = None
     page = 1
     items_per_page = 10
-    page_query = 'page'
+    page_field = 'page'
 
     def setup_paginator(self, request, items):
-        self.page = request.GET.get(self.page_query, 1)
+        self.page = request.GET.get(self.page_field, 1)
         self.paginator = Paginator(items, self.items_per_page)
 
     def get_page(self):
@@ -83,7 +83,7 @@ class PaginatedFeedMixin(object):
 
         kwargs = {}
 
-        kwargs.setdefault('page_query', self.page_query)
+        kwargs.setdefault('page_field', self.page_field)
         if page.has_next():
             kwargs.setdefault('next_page', page.next_page_number())
 
@@ -101,7 +101,7 @@ class LatestEventsFeed(PaginatedFeedMixin, Feed):
     subtitle = '10 most recent major PREMIS events.'
     author_name = 'Major Event Log'
     author_link = 'http://digital2.library.unt.edu/name/nm0005293/'
-    page_query = 'p'
+    page_field = 'p'
 
     def get_object(self, request):
         display = Event.objects.order_by('-date')

--- a/major_event_log/feeds.py
+++ b/major_event_log/feeds.py
@@ -8,7 +8,7 @@ from django.core.paginator import Paginator
 from .models import Event
 
 
-class PaginatedFeedTypeMixin(object):
+class PaginatedAtom1FeedMixin(object):
 
     def _create_link_attr(self, rel, page):
         href = u'{0}?{1}={2}'.format(
@@ -68,7 +68,7 @@ class PaginatedFeedTypeMixin(object):
             handler.addQuickElement("rights", self.feed['feed_copyright'])
 
 
-class MajorEventLogFeed(PaginatedFeedTypeMixin, Atom1Feed):
+class MajorEventLogFeed(PaginatedAtom1FeedMixin, Atom1Feed):
     """Custom Atom Feed for Event objects.
 
     The only changes between this custom feed and the base Atom Feed

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -98,6 +98,83 @@ class TestViewsCalled(TestCase):
         self.assertEqual(resolve(url).func, views.about)
 
 
+class TestFeed(TestCase):
+    """Test the custom pagination functionality added to the feed."""
+
+    @classmethod
+    def setUpTestData(cls):
+        [create_event() for _ in range(31)]
+
+    def test_has_first_link(self):
+        """Check that the href on the `first` link is present and
+        correct.
+        """
+        url = reverse('major-event-log:feed')
+        response = self.client.get(url, {'p': 2})
+        feed = etree.fromstring(response.content)
+
+        link = feed.xpath(
+            '/ns:feed/ns:link[@rel=\'first\']',
+            namespaces={'ns': 'http://www.w3.org/2005/Atom'}
+        )
+        self.assertTrue('/feed/?p=1' in link[0].attrib.get('href'))
+
+    def test_has_next_link(self):
+        """Check that the href on the `next` link is present and
+        correct.
+        """
+        url = reverse('major-event-log:feed')
+        response = self.client.get(url, {'p': 2})
+        feed = etree.fromstring(response.content)
+
+        link = feed.xpath(
+            '/ns:feed/ns:link[@rel=\'next\']',
+            namespaces={'ns': 'http://www.w3.org/2005/Atom'}
+        )
+        self.assertTrue('/feed/?p=3' in link[0].attrib.get('href'))
+
+    def test_has_previous_link(self):
+        """Check that the href on the `previous` link is present and
+        correct.
+        """
+        url = reverse('major-event-log:feed')
+        response = self.client.get(url, {'p': 2})
+        feed = etree.fromstring(response.content)
+
+        link = feed.xpath(
+            '/ns:feed/ns:link[@rel=\'previous\']',
+            namespaces={'ns': 'http://www.w3.org/2005/Atom'}
+        )
+
+        self.assertTrue('/feed/?p=1' in link[0].attrib.get('href'))
+
+    def test_has_last_link(self):
+        """Check that the href on the `last` link is present and
+        correct.
+        """
+        url = reverse('major-event-log:feed')
+        response = self.client.get(url, {'p': 2})
+        feed = etree.fromstring(response.content)
+
+        link = feed.xpath(
+            '/ns:feed/ns:link[@rel=\'last\']',
+            namespaces={'ns': 'http://www.w3.org/2005/Atom'}
+        )
+        self.assertTrue('/feed/?p=4' in link[0].attrib.get('href'))
+
+    def test_number_of_items_per_page(self):
+        """Check that, at most, 10 events are listed per page."""
+        url = reverse('major-event-log:feed')
+        response = self.client.get(url)
+        feed = etree.fromstring(response.content)
+
+        entries = feed.xpath(
+            '/ns:feed/ns:entry',
+            namespaces={'ns': 'http://www.w3.org/2005/Atom'}
+        )
+        self.assertEqual(len(entries), 10)
+
+
 class TestTemplateUsed(TestCase):
     """Test that the correct template is called by the views."""
 


### PR DESCRIPTION
~~FYI: This will fail the flake8 check.~~

So here is what is going on with this.

I have created 2 mixins (`PaginatedFeedMixin`, and `PaginatedFeedTypeMixin`).

`PaginatedFeedMixin` sets of the Feed object with some class variables and adds some helper functions to setup of the paginator, and to send additional kwargs to the FeedType object.

`PaginatedFeedMixin` adds a `_create_link_attr()` and overrides `add_root_elements()`.
`add_root_elements()` is taken directly from [here](https://github.com/django/django/blob/bc77eb6d0858652e197c08c299efaeb06c51efee/django/utils/feedgenerator.py#L349-L369), but the paginated links are added in between the `feed_url` element and the `author_name`.

I am still very unfamiliar with the Sax utilities that Django uses to write the XML. I was looking for a way to call `super` on `add_root_elements`, and then jump back to specific point in the document to write the additional link elements. Since Sax does **not** use a DOM, I am not sure if that approach is possible.
