### PR TITLE
Upgrade to Django4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,12 +8,12 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python: [3.6, 3.7, 3.8, 3.9]
+        python: ['3.8', '3.9', '3.10']
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
       - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
         python: ['3.8', '3.9', '3.10']
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v2
       - name: Setup Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
         python: ['3.8', '3.9', '3.10']
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Python
         uses: actions/setup-python@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ Change Log
 ==========
 
 
-1.1.0
+2.0.0
 -----
 * Upgraded to Django 4.1.
 * Removed support for Django 2.2.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@ Change Log
 ==========
 
 
+1.1.0
+-----
+* Upgraded to Django 4.1
+* Removed support for Django 2.2
+* Removed support for Python 3.6 and 3.7
+* Added support for Python 3.10
+
+
 1.0.0
 -----
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@ Change Log
 
 1.1.0
 -----
-* Upgraded to Django 4.1
-* Removed support for Django 2.2
-* Removed support for Python 3.6 and 3.7
-* Added support for Python 3.10
+* Upgraded to Django 4.1.
+* Removed support for Django 2.2.
+* Removed support for Python 3.6 and 3.7.
+* Added support for Python 3.10.
 
 
 1.0.0

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ displaying events with various levels of detail.
 Requirements
 --------------------------
 
-- Django 2.2
-- Python 3.6-3.7
+- Django 4.1
+- Python 3.8-3.10
 
 
 Installation

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Contributors:
 * [Gio Gottardi](https://github.com/somexpert)
 * [Damon Kelley](https://github.com/damonkelley)
 * [Madhulika Bayyavarapu](https://github.com/madhulika95b)
+* [Gracie Flores-Hays](https://github.com/gracieflores)
 
 
 Developing/Testing

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,3 +31,4 @@ Contributors
 - `Gio Gottardi <http://github.com/somexpert/>`_
 - `Damon Kelley <http://github.com/damonkelley/>`_
 - `Madhulika Bayyavarapu <http://github.com/madhulika95b/>`_
+- `Gracie Flores-Hays <http://github.com/gracieflores/>`_

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -4,8 +4,8 @@ Installation
 Requirements
 ------------
 
--  Django 2.2
--  Python 3.5 - 3.7
+-  Django 4.1
+-  Python 3.8 - 3.10
 
 Installing
 ----------

--- a/major_event_log/models.py
+++ b/major_event_log/models.py
@@ -32,7 +32,7 @@ class Event(models.Model):
     contact_email = models.EmailField()
 
     def get_absolute_url(self):
-        return(reverse('major-event-log:event_details', args=[self.id]))
+        return (reverse('major-event-log:event_details', args=[self.id]))
 
     def is_success(self):
         return self.outcome == self.SUCCESS
@@ -40,5 +40,5 @@ class Event(models.Model):
     class Meta:
         ordering = ['date']
 
-    def __unicode__(self):
+    def __str__(self):
         return self.title

--- a/major_event_log/models.py
+++ b/major_event_log/models.py
@@ -32,7 +32,7 @@ class Event(models.Model):
     contact_email = models.EmailField()
 
     def get_absolute_url(self):
-        return (reverse('major-event-log:event_details', args=[self.id]))
+        return reverse('major-event-log:event_details', args=[self.id])
 
     def is_success(self):
         return self.outcome == self.SUCCESS

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,2 @@
 -r requirements-test.txt
-django~=2.2.17
+django~=4.1.2

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='django-major-event-log',
-    version='1.1.0',
+    version='2.0.0',
     packages=find_packages(exclude=['tests*']),
     description='Django app for keeping track of major premis events.',
     long_description='See the home page for more information.',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='django-major-event-log',
-    version='1.0.0',
+    version='1.1.0',
     packages=find_packages(exclude=['tests*']),
     description='Django app for keeping track of major premis events.',
     long_description='See the home page for more information.',

--- a/setup.py
+++ b/setup.py
@@ -15,11 +15,11 @@ setup(
     classifiers=[
         'Natural Language :: English',
         'Environment :: Web Environment',
-        'Framework :: Django :: 2.2',
+        'Framework :: Django :: 4.1',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
     ]
 )

--- a/tests/settings/base.py
+++ b/tests/settings/base.py
@@ -50,8 +50,6 @@ TIME_ZONE = 'UTC'
 
 USE_I18N = True
 
-USE_L10N = True
-
 USE_TZ = True
 
 STATIC_URL = '/static/'

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37,38,39}-django22, py37-flake8
+envlist = py{38,39,310}-django41, py39-flake8
 
 [pytest]
 DJANGO_SETTINGS_MODULE = tests.settings.test
@@ -12,10 +12,10 @@ max-line-length = 99
 [testenv]
 deps =
     -rrequirements-test.txt
-    django22: Django~=2.2.17
+    django41: Django~=4.1.2
 commands = pytest
 
-[testenv:py37-flake8]
+[testenv:py39-flake8]
 skip_install = True
 deps = flake8
 commands = flake8 major_event_log tests setup.py


### PR DESCRIPTION
The changes are similar to `django-citeIt`. You will see two additional changes to models.py. One was to add a space to the return per flake8 and the other was changing the unicode method to str. This has been tested locally with `Python 3.9` using the admin to add instances of an event.